### PR TITLE
Fix/multilevel switch

### DIFF
--- a/rmf_visualization_building_systems/rmf_visualization_building_systems/rmf_visualization_building_systems.py
+++ b/rmf_visualization_building_systems/rmf_visualization_building_systems/rmf_visualization_building_systems.py
@@ -63,7 +63,7 @@ class BuildingSystemsVisualizer(Node):
 
         self.create_subscription(
             RvizParam,
-            'rviz_node/param',
+            'rmf_visualization/parameter',
             self.param_cb,
             qos_profile=qos_profile_system_default)
 

--- a/rmf_visualization_fleet_states/rmf_visualization_fleet_states/rmf_visualization_fleet_states.py
+++ b/rmf_visualization_fleet_states/rmf_visualization_fleet_states/rmf_visualization_fleet_states.py
@@ -40,7 +40,7 @@ class FleetStateVisualizer(Node):
 
         self.create_subscription(
             RvizParam,
-            'rviz_node/param',
+            'rmf_visualization/parameter',
             self.param_cb,
             qos_profile=qos_profile_system_default)
 

--- a/rmf_visualization_rviz2_plugins/src/SchedulePanel.cpp
+++ b/rmf_visualization_rviz2_plugins/src/SchedulePanel.cpp
@@ -33,7 +33,7 @@ using namespace std::chrono_literals;
 
 SchedulePanel::SchedulePanel(QWidget* parent)
 : rviz_common::Panel(parent),
-  _param_topic("/rviz_node/param"),
+  _param_topic("/rmf_visualization/parameter"),
   _map_name("B1"),
   _finish_duration("600"),
   _start_duration_value(0)

--- a/rmf_visualization_schedule/config/rmf.rviz
+++ b/rmf_visualization_schedule/config/rmf.rviz
@@ -24,7 +24,7 @@ Panels:
     Splitter Ratio: 0.5
   - Class: rviz_common/Selection
     Name: Selection
-  - Class: rmf_visualization_schedule/SchedulePanel
+  - Class: rmf_visualization_rviz2_plugins/SchedulePanel
     Finish: 600
     Map: B1
     Name: SchedulePanel

--- a/rmf_visualization_schedule/config/rmf.rviz
+++ b/rmf_visualization_schedule/config/rmf.rviz
@@ -24,7 +24,7 @@ Panels:
     Splitter Ratio: 0.5
   - Class: rviz_common/Selection
     Name: Selection
-  - Class: rviz2_plugin/SchedulePanel
+  - Class: rmf_visualization_schedule/SchedulePanel
     Finish: 600
     Map: B1
     Name: SchedulePanel

--- a/rmf_visualization_schedule/src/ScheduleMarkerPublisher.hpp
+++ b/rmf_visualization_schedule/src/ScheduleMarkerPublisher.hpp
@@ -116,7 +116,7 @@ public:
     auto sub_param_opt = rclcpp::SubscriptionOptions();
     sub_param_opt.callback_group = _cb_group_param_sub;
     _param_sub = this->create_subscription<RvizParamMsg>(
-      "rviz_node/param",
+      "rmf_visualization/parameter",
       rclcpp::QoS(10),
       [&](RvizParamMsg::SharedPtr msg)
       {

--- a/rmf_visualization_schedule/src/ScheduleMarkerPublisher.hpp
+++ b/rmf_visualization_schedule/src/ScheduleMarkerPublisher.hpp
@@ -116,7 +116,7 @@ public:
     auto sub_param_opt = rclcpp::SubscriptionOptions();
     sub_param_opt.callback_group = _cb_group_param_sub;
     _param_sub = this->create_subscription<RvizParamMsg>(
-      node_name + "/param",
+      "rviz_node/param",
       rclcpp::QoS(10),
       [&](RvizParamMsg::SharedPtr msg)
       {


### PR DESCRIPTION
### Issue
 - If launch a multi-level demos ( `clinic.launch.xml`), not able to switch different level from rviz side panel.
 - `rmf.rviz` failed to load `SchedulePanel`.

### Fix
 - Match `RvizParamMsg` topic name.
 - `rviz2_plugin` -> `rmf_visualization_schedule`


