### PR TITLE
Inconsistent topic name for viz param

### DIFF
--- a/rmf_visualization_building_systems/rmf_visualization_building_systems/rmf_visualization_building_systems.py
+++ b/rmf_visualization_building_systems/rmf_visualization_building_systems/rmf_visualization_building_systems.py
@@ -63,7 +63,7 @@ class BuildingSystemsVisualizer(Node):
 
         self.create_subscription(
             RvizParam,
-            'rmf_visualization/parameter',
+            'rmf_visualization/parameters',
             self.param_cb,
             qos_profile=qos_profile_system_default)
 

--- a/rmf_visualization_fleet_states/rmf_visualization_fleet_states/rmf_visualization_fleet_states.py
+++ b/rmf_visualization_fleet_states/rmf_visualization_fleet_states/rmf_visualization_fleet_states.py
@@ -40,7 +40,7 @@ class FleetStateVisualizer(Node):
 
         self.create_subscription(
             RvizParam,
-            'rmf_visualization/parameter',
+            'rmf_visualization/parameters',
             self.param_cb,
             qos_profile=qos_profile_system_default)
 

--- a/rmf_visualization_rviz2_plugins/src/SchedulePanel.cpp
+++ b/rmf_visualization_rviz2_plugins/src/SchedulePanel.cpp
@@ -33,7 +33,7 @@ using namespace std::chrono_literals;
 
 SchedulePanel::SchedulePanel(QWidget* parent)
 : rviz_common::Panel(parent),
-  _param_topic("/rmf_visualization/parameter"),
+  _param_topic("/rmf_visualization/parameters"),
   _map_name("B1"),
   _finish_duration("600"),
   _start_duration_value(0)

--- a/rmf_visualization_schedule/config/rmf.rviz
+++ b/rmf_visualization_schedule/config/rmf.rviz
@@ -28,7 +28,7 @@ Panels:
     Finish: 600
     Map: B1
     Name: SchedulePanel
-    Topic: /rmf_visualization/parameter
+    Topic: /rmf_visualization/parameters
 Visualization Manager:
   Class: ""
   Displays:

--- a/rmf_visualization_schedule/src/ScheduleMarkerPublisher.hpp
+++ b/rmf_visualization_schedule/src/ScheduleMarkerPublisher.hpp
@@ -116,7 +116,7 @@ public:
     auto sub_param_opt = rclcpp::SubscriptionOptions();
     sub_param_opt.callback_group = _cb_group_param_sub;
     _param_sub = this->create_subscription<RvizParamMsg>(
-      "rmf_visualization/parameter",
+      "rmf_visualization/parameters",
       rclcpp::QoS(10),
       [&](RvizParamMsg::SharedPtr msg)
       {


### PR DESCRIPTION
The topic name `rmf_visualization/parameters` should be plural. This is an overlooked mistake from my previous pr:  https://github.com/open-rmf/rmf_visualization/pull/12