### PR TITLE
bump ros tooling due to key expiration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: deps
-        uses: ros-tooling/setup-ros@v0.1
+        uses: ros-tooling/setup-ros@v0.2
         with:
           required-ros-distributions: foxy
       - name: build


### PR DESCRIPTION
## Bug fix

### Fixed bug

Bumping ROS tooling to fix recent key expiration on ci