### PR TITLE
removing nlohmann-json dependencies

### DIFF
--- a/rmf_visualization_schedule/include/jwt/jwt.hpp
+++ b/rmf_visualization_schedule/include/jwt/jwt.hpp
@@ -38,7 +38,7 @@ SOFTWARE.
 #include "jwt/string_view.hpp"
 #include "jwt/parameters.hpp"
 #include "jwt/exceptions.hpp"
-#include "nlohmann/json.hpp"
+#include "json.hpp"
 
 // For convenience
 using json_t = nlohmann::json;

--- a/rmf_visualization_schedule/package.xml
+++ b/rmf_visualization_schedule/package.xml
@@ -24,7 +24,6 @@
   <depend>builtin_interfaces</depend>
   <depend>eigen</depend>
   <depend>libopencv-dev</depend>
-  <depend>nlohmann-json-dev</depend>
   <depend>libssl-dev</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

Removing some of the old nlohmann-json dependencies
