### PR TITLE
websocketpp needs boost for asio

### DIFF
--- a/rmf_visualization_schedule/package.xml
+++ b/rmf_visualization_schedule/package.xml
@@ -25,6 +25,7 @@
   <depend>eigen</depend>
   <depend>libopencv-dev</depend>
   <depend>libssl-dev</depend>
+  <depend>libboost-dev</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

In order to use the `asio` transport out of `websocketpp` there's two options: either use the one from `libboost-dev` or use the standalone version which involves installing `libasio-dev` and setting `ASIO_STANDALONE` at compile time. It seems that `libasio-dev` suggests  `libboost-dev` anyway so I went for the later option. With that said, I'm open to to change the to standalone if we find any benefits.