### PR TITLE
Fix the style checking in CI

### DIFF
--- a/rmf_visualization_rviz2_plugins/CMakeLists.txt
+++ b/rmf_visualization_rviz2_plugins/CMakeLists.txt
@@ -33,6 +33,19 @@ find_package(rviz_default_plugins REQUIRED)
 find_package(rmf_traffic_ros2 REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Widgets Test)
 
+if(BUILD_TESTING)
+  find_package(rmf_cmake_uncrustify REQUIRED)
+  find_file(uncrustify_config_file
+    NAMES "rmf_code_style.cfg"
+    PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
+
+  rmf_uncrustify(
+    src test
+    CONFIG_FILE ${uncrustify_config_file}
+    MAX_LINE_LENGTH 80
+  )
+endif()
+
 add_definitions(-DQT_NO_KEYWORDS)
 
 add_library(${PROJECT_NAME} SHARED 

--- a/rmf_visualization_rviz2_plugins/package.xml
+++ b/rmf_visualization_rviz2_plugins/package.xml
@@ -27,6 +27,8 @@
   <exec_depend>libqt5-gui</exec_depend>
   <exec_depend>libqt5-widgets</exec_depend>
 
+  <test_depend>rmf_cmake_uncrustify</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/rmf_visualization_rviz2_plugins/src/DoorPanel.cpp
+++ b/rmf_visualization_rviz2_plugins/src/DoorPanel.cpp
@@ -376,4 +376,6 @@ QString DoorPanel::door_state_mode_tooltip() const
 } // namespace rmf_visualization_rviz2_plugins
 
 #include <pluginlib/class_list_macros.hpp>
-PLUGINLIB_EXPORT_CLASS(rmf_visualization_rviz2_plugins::DoorPanel, rviz_common::Panel)
+PLUGINLIB_EXPORT_CLASS(
+  rmf_visualization_rviz2_plugins::DoorPanel,
+  rviz_common::Panel)

--- a/rmf_visualization_rviz2_plugins/src/LiftPanel.cpp
+++ b/rmf_visualization_rviz2_plugins/src/LiftPanel.cpp
@@ -516,4 +516,6 @@ QString LiftPanel::lift_mode_tooltip() const
 } // namespace rmf_visualization_rviz2_plugins
 
 #include <pluginlib/class_list_macros.hpp>
-PLUGINLIB_EXPORT_CLASS(rmf_visualization_rviz2_plugins::LiftPanel, rviz_common::Panel)
+PLUGINLIB_EXPORT_CLASS(
+  rmf_visualization_rviz2_plugins::LiftPanel,
+  rviz_common::Panel)

--- a/rmf_visualization_rviz2_plugins/src/SchedulePanel.cpp
+++ b/rmf_visualization_rviz2_plugins/src/SchedulePanel.cpp
@@ -338,4 +338,6 @@ void SchedulePanel::load(const rviz_common::Config& config)
 } // namespace rmf_visualization_rviz2_plugins
 
 #include <pluginlib/class_list_macros.hpp>
-PLUGINLIB_EXPORT_CLASS(rmf_visualization_rviz2_plugins::SchedulePanel, rviz_common::Panel)
+PLUGINLIB_EXPORT_CLASS(
+  rmf_visualization_rviz2_plugins::SchedulePanel,
+  rviz_common::Panel)

--- a/rmf_visualization_schedule/CMakeLists.txt
+++ b/rmf_visualization_schedule/CMakeLists.txt
@@ -31,14 +31,14 @@ find_package(rmf_visualization_msgs REQUIRED)
 find_package(rmf_building_map_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
 
-find_package(rmf_cmake_uncrustify QUIET)
-if(BUILD_TESTING AND rmf_cmake_uncrustify_FOUND)
+if(BUILD_TESTING)
+  find_package(rmf_cmake_uncrustify REQUIRED)
   find_file(uncrustify_config_file 
     NAMES "rmf_code_style.cfg"
     PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 
   rmf_uncrustify(
-    ARGN include/rmf_visualization_schedule src test
+    include/rmf_visualization_schedule src test
     CONFIG_FILE ${uncrustify_config_file}
     MAX_LINE_LENGTH 80
   )

--- a/rmf_visualization_schedule/package.xml
+++ b/rmf_visualization_schedule/package.xml
@@ -29,6 +29,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rmf_cmake_uncrustify</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/rmf_visualization_schedule/src/rmf_visualization_schedule/TrajectoryServer.cpp
+++ b/rmf_visualization_schedule/src/rmf_visualization_schedule/TrajectoryServer.cpp
@@ -130,8 +130,11 @@ auto TrajectoryServer::Implementation::on_message(
     try
     {
       token = Json::parse(msg->get_payload())["token"];
-      auto decoded = jwt::decode(token, jwt::params::algorithms({"RS256"}), jwt::params::secret(public_key));
-    } 
+      auto decoded = jwt::decode(
+        token,
+        jwt::params::algorithms({"RS256"}),
+        jwt::params::secret(public_key));
+    }
     catch (std::exception& e)
     {
       is_verified = false;


### PR DESCRIPTION
It turns out that style checking wasn't quite working correctly for the `rmf_visualization` C++ libraries. This PR fixes that by making sure that colcon knows `rmf_cmake_uncrustify` is needed for testing.