### PR TITLE
Use ament_cmake_uncrustify

### DIFF
--- a/rmf_visualization_rviz2_plugins/CMakeLists.txt
+++ b/rmf_visualization_rviz2_plugins/CMakeLists.txt
@@ -34,12 +34,12 @@ find_package(rmf_traffic_ros2 REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Widgets Test)
 
 if(BUILD_TESTING)
-  find_package(rmf_cmake_uncrustify REQUIRED)
+  find_package(ament_cmake_uncrustify REQUIRED)
   find_file(uncrustify_config_file
     NAMES "rmf_code_style.cfg"
     PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 
-  rmf_uncrustify(
+  ament_uncrustify(
     src test
     CONFIG_FILE ${uncrustify_config_file}
     MAX_LINE_LENGTH 80
@@ -48,7 +48,7 @@ endif()
 
 add_definitions(-DQT_NO_KEYWORDS)
 
-add_library(${PROJECT_NAME} SHARED 
+add_library(${PROJECT_NAME} SHARED
   src/SchedulePanel.cpp
   src/LiftPanel.cpp
   src/DoorPanel.cpp
@@ -57,7 +57,7 @@ add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
-    ${QT5_LIBRARIES} 
+    ${QT5_LIBRARIES}
     ${rclcpp_LIBRARIES}
     ${rmf_door_msgs_LIBRARIES}
     ${rmf_lift_msgs_LIBRARIES}

--- a/rmf_visualization_rviz2_plugins/package.xml
+++ b/rmf_visualization_rviz2_plugins/package.xml
@@ -27,7 +27,7 @@
   <exec_depend>libqt5-gui</exec_depend>
   <exec_depend>libqt5-widgets</exec_depend>
 
-  <test_depend>rmf_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_visualization_schedule/CMakeLists.txt
+++ b/rmf_visualization_schedule/CMakeLists.txt
@@ -32,12 +32,12 @@ find_package(rmf_building_map_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
 
 if(BUILD_TESTING)
-  find_package(rmf_cmake_uncrustify REQUIRED)
-  find_file(uncrustify_config_file 
+  find_package(ament_cmake_uncrustify REQUIRED)
+  find_file(uncrustify_config_file
     NAMES "rmf_code_style.cfg"
     PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 
-  rmf_uncrustify(
+  ament_uncrustify(
     include/rmf_visualization_schedule src test
     CONFIG_FILE ${uncrustify_config_file}
     MAX_LINE_LENGTH 80

--- a/rmf_visualization_schedule/package.xml
+++ b/rmf_visualization_schedule/package.xml
@@ -29,7 +29,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>rmf_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 


### PR DESCRIPTION
We currently have the rmf_cmake_uncrustify package that is used for style checking with colcon test. The original reason for having this package and not using ament_cmake_uncrustify was that the latter did not support custom uncrustify configuration files. But this feature was [merged upstream](https://github.com/ament/ament_lint/pull/200) quite a while ago and has been part of `foxy` and `galactic` releases. Hence, switching back to `ament_cmake_uncrustify` for ease of maintenance and distribution.