### PR TITLE
Fix setup deprecation warning

### DIFF
--- a/rmf_visualization_building_systems/setup.cfg
+++ b/rmf_visualization_building_systems/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/rmf_visualization_building_systems
+script_dir=$base/lib/rmf_visualization_building_systems
 [install]
-install-scripts=$base/lib/rmf_visualization_building_systems
+install_scripts=$base/lib/rmf_visualization_building_systems

--- a/rmf_visualization_fleet_states/setup.cfg
+++ b/rmf_visualization_fleet_states/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/rmf_visualization_fleet_states
+script_dir=$base/lib/rmf_visualization_fleet_states
 [install]
-install-scripts=$base/lib/rmf_visualization_fleet_states
+install_scripts=$base/lib/rmf_visualization_fleet_states


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fixes the warning about setup.cfg format:

```
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
```

### Fix applied

Changed as mentioned in the warning.
It appears as pretty innocuous but suddenly due to possibly an update in colcon, or jammy (unclear really) Python executables are not found anymore and this fails:

```
ros2 run rmf_visualization_fleet_states rmf_visualization_fleet_states
```

While this succeeds:

```
rmf_visualization_fleet_states
```

This breaks all the demos since the launch files can't find the nodes anymore and this change seems to fix it