### PR TITLE
fix eigen not found when building rmp

### DIFF
--- a/rmf_visualization_floorplans/CMakeLists.txt
+++ b/rmf_visualization_floorplans/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 include(GNUInstallDirs)
 
+find_package(eigen3_cmake_module REQUIRED)
 set(dep_pkgs
   rclcpp
   rclcpp_components

--- a/rmf_visualization_floorplans/package.xml
+++ b/rmf_visualization_floorplans/package.xml
@@ -8,6 +8,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>


### PR DESCRIPTION
https://build.ros2.org/job/Hbin_rhel_el864__rmf_visualization_floorplans__rhel_8_x86_64__binary/41/console

```
08:19:19 DEBUG: CMake Error at CMakeLists.txt:25 (add_library):
08:19:19 DEBUG:   Target "floorplan_visualizer" links to target "Eigen3::Eigen" but the
08:19:19 DEBUG:   target was not found.  Perhaps a find_package() call is missing for an
08:19:19 DEBUG:   IMPORTED target, or an ALIAS target is missing?
08:19:19 DEBUG: -- Generating done
Looking for the package in https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml#L6554
Eigen3 is correctly installed 08:19:16 DEBUG: eigen3-devel-3.3.4-6.el8.noarch 1575283471 6784228 52c4b0561bf717f0d220260fe21674a1 installed
Found by cmake 08:19:19 DEBUG: -- Found Eigen3: /usr/include/eigen3 (Required is at least version "2.91.0")
```

Fixing with this [eigen3_cmake_module](https://github.com/ros2/eigen3_cmake_module)