### PR TITLE
Improve linking times (#61)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,5 +20,5 @@ jobs:
         rmf_visualization_obstacles
         rmf_visualization_rviz2_plugins
         rmf_visualization_schedule
-      dist-matrix: '[{"ros_distribution": "humble", "ubuntu_distribution": "jammy"}, {"ros_distribution": "rolling", "ubuntu_distribution": "jammy"}]'
+      dist-matrix: '[{"ros_distribution": "iron", "ubuntu_distribution": "jammy"}]'
 

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker_image: ['ros:humble-ros-base']
+        docker_image: ['ros:iron-ros-base']
     container:
       image: ${{ matrix.docker_image }}
     steps:

--- a/rmf_visualization_fleet_states/CMakeLists.txt
+++ b/rmf_visualization_fleet_states/CMakeLists.txt
@@ -22,26 +22,20 @@ endforeach()
 #===============================================================================
 add_library(fleetstates_visualizer SHARED src/FleetStatesVisualizer.cpp)
 
-target_link_libraries(fleetstates_visualizer
-  PRIVATE
-    rclcpp::rclcpp
-    ${rclcpp_components_LIBRARIES}
-    ${rmf_fleet_msgs_LIBRARIES}
-    ${rmf_visualization_msgs_LIBRARIES}
-    ${visualization_msgs_LIBRARIES}
-    ${geometry_msgs_LIBRARIES}
+ament_target_dependencies(fleetstates_visualizer
+  PUBLIC
+    rclcpp
+    rclcpp_components
+    rmf_fleet_msgs
+    rmf_visualization_msgs
+    visualization_msgs
+    geometry_msgs
 )
 
 target_include_directories(fleetstates_visualizer
   PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    ${rclcpp_INCLUDE_DIRS}
-    ${rclcpp_components_INCLUDE_DIRS}
-    ${rmf_fleet_msgs_INCLUDE_DIRS}
-    ${rmf_visualization_msgs_INCLUDE_DIRS}
-    ${visualization_msgs_INCLUDE_DIRS}
-    ${geometry_msgs_INCLUDE_DIRS}
 )
 
 target_compile_features(fleetstates_visualizer INTERFACE cxx_std_17)

--- a/rmf_visualization_floorplans/CMakeLists.txt
+++ b/rmf_visualization_floorplans/CMakeLists.txt
@@ -25,32 +25,23 @@ endforeach()
 #===============================================================================
 add_library(floorplan_visualizer SHARED src/FloorplanVisualizer.cpp)
 
-target_link_libraries(floorplan_visualizer
-  PRIVATE
-    rclcpp::rclcpp
-    Eigen3::Eigen
-    ${rclcpp_components_LIBRARIES}
-    ${OpenCV_LIBRARIES}
-    ${rmf_building_map_msgs_LIBRARIES}
-    ${rmf_visualization_msgs_LIBRARIES}
-    ${nav_msgs_LIBRARIES}
-    ${geometry_msgs_LIBRARIES}
-
+ament_target_dependencies(floorplan_visualizer
+  PUBLIC
+    rclcpp
+    Eigen3
+    rclcpp_components
+    OpenCV
+    rmf_building_map_msgs
+    rmf_visualization_msgs
+    nav_msgs
+    geometry_msgs
 )
+
 
 target_include_directories(floorplan_visualizer
   PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    ${rclcpp_INCLUDE_DIRS}
-    ${rclcpp_components_INCLUDE_DIRS}
-    ${OpenCV_INCLUDE_DIRS}
-    ${Eigen3_INCLUDE_DIRS}
-    ${rmf_fleet_msgs_INCLUDE_DIRS}
-    ${rmf_building_map_msgs_INCLUDE_DIRS}
-    ${rmf_visualization_msgs_INCLUDE_DIRS}
-    ${nav_msgs_INCLUDE_DIRS}
-    ${geometry_msgs_INCLUDE_DIRS}
 )
 
 target_compile_features(floorplan_visualizer INTERFACE cxx_std_17)

--- a/rmf_visualization_navgraphs/CMakeLists.txt
+++ b/rmf_visualization_navgraphs/CMakeLists.txt
@@ -26,33 +26,22 @@ endforeach()
 #===============================================================================
 add_library(navgraph_visualizer SHARED src/NavGraphVisualizer.cpp)
 
-target_link_libraries(navgraph_visualizer
-  PRIVATE
-    rclcpp::rclcpp
-    ${rclcpp_components_LIBRARIES}
-    ${rmf_fleet_msgs_LIBRARIES}
-    ${rmf_building_map_msgs_LIBRARIES}
-    ${rmf_visualization_msgs_LIBRARIES}
-    ${visualization_msgs_LIBRARIES}
-    ${geometry_msgs_LIBRARIES}
-    rmf_traffic::rmf_traffic
-    rmf_traffic_ros2::rmf_traffic_ros2
-
+ament_target_dependencies(navgraph_visualizer
+  PUBLIC
+    rclcpp
+    rclcpp_components
+    rmf_fleet_msgs
+    rmf_building_map_msgs
+    rmf_visualization_msgs
+    visualization_msgs
+    geometry_msgs
+    rmf_traffic_ros2
 )
 
 target_include_directories(navgraph_visualizer
   PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    ${rclcpp_INCLUDE_DIRS}
-    ${rclcpp_components_INCLUDE_DIRS}
-    ${rmf_fleet_msgs_INCLUDE_DIRS}
-    ${rmf_building_map_msgs_INCLUDE_DIRS}
-    ${rmf_visualization_msgs_INCLUDE_DIRS}
-    ${visualization_msgs_INCLUDE_DIRS}
-    ${geometry_msgs_INCLUDE_DIRS}
-    ${rmf_traffic_INCLUDE_DIRS}
-    ${rmf_traffic_ros2_INCLUDE_DIRS}
 )
 
 target_compile_features(navgraph_visualizer INTERFACE cxx_std_17)

--- a/rmf_visualization_obstacles/CMakeLists.txt
+++ b/rmf_visualization_obstacles/CMakeLists.txt
@@ -18,26 +18,15 @@ find_package(rmf_visualization_msgs REQUIRED)
 #===============================================================================
 add_library(obstacle_visualizer SHARED src/ObstacleVisualizer.cpp)
 
-target_link_libraries(obstacle_visualizer
-  PRIVATE
-    rclcpp::rclcpp
-    ${rclcpp_components_LIBRARIES}
-    ${visualization_msgs_LIBRARIES}
-    ${geometry_msgs_LIBRARIES}
-    ${vision_msgs_LIBRARIES}
-    ${rmf_obstacle_msgs_LIBRARIES}
-    ${rmf_visualization_msgs_LIBRARIES}
-)
-
-target_include_directories(obstacle_visualizer
+ament_target_dependencies(obstacle_visualizer
   PUBLIC
-    ${rclcpp_INCLUDE_DIRS}
-    ${rclcpp_components_INCLUDE_DIRS}
-    ${visualization_msgs_INCLUDE_DIRS}
-    ${geometry_msgs_INCLUDE_DIRS}
-    ${vision_msgs_INCLUDE_DIRS}
-    ${rmf_obstacle_msgs_INCLUDE_DIRS}
-    ${rmf_visualization_msgs_INCLUDE_DIRS}
+    rclcpp
+    rclcpp_components
+    visualization_msgs
+    geometry_msgs
+    vision_msgs
+    rmf_obstacle_msgs
+    rmf_visualization_msgs
 )
 
 target_compile_features(obstacle_visualizer INTERFACE cxx_std_17)

--- a/rmf_visualization_rviz2_plugins/CMakeLists.txt
+++ b/rmf_visualization_rviz2_plugins/CMakeLists.txt
@@ -56,31 +56,28 @@ add_library(${PROJECT_NAME} SHARED
   src/NegotiationModel.cpp
 )
 
+ament_target_dependencies(${PROJECT_NAME}
+  PUBLIC
+    rclcpp
+    rmf_door_msgs
+    rmf_lift_msgs
+    rmf_visualization_msgs
+    rmf_traffic_ros2
+    rviz_common
+    rviz_rendering
+    rviz_default_plugins
+)
+
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
     ${QT5_LIBRARIES}
-    ${rclcpp_LIBRARIES}
-    ${rmf_door_msgs_LIBRARIES}
-    ${rmf_lift_msgs_LIBRARIES}
-    ${rmf_visualization_msgs_LIBRARIES}
-    rviz_common::rviz_common
-    ${rviz_rendering_LIBRARIES}
-    ${rviz_default_plugins_LIBRARIES}
     ${Qt5Widgets_LIBRARIES}
-    rmf_traffic_ros2::rmf_traffic_ros2
 )
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
-    ${rclcpp_INCLUDE_DIRS}
-    ${rmf_door_msgs_INCLUDE_DIRS}
-    ${rmf_lift_msgs_INCLUDE_DIRS}
-    ${rmf_visualization_msgs_INCLUDE_DIRS}
-    ${rviz_common_INCLUDE_DIRS}
-    ${rviz_rendering_INCLUDE_DIRS}
-    ${rviz_default_plugins_INCLUDE_DIRS}
     ${Qt5Widgets_INCLUDE_DIRS}
     ${QT5_INCLUDE_DIRS}
 )

--- a/rmf_visualization_schedule/CMakeLists.txt
+++ b/rmf_visualization_schedule/CMakeLists.txt
@@ -48,25 +48,20 @@ endif()
 file(GLOB_RECURSE core_lib_srcs "src/rmf_visualization_schedule/*.cpp")
 add_library(rmf_visualization_schedule SHARED ${core_lib_srcs})
 
-target_link_libraries(rmf_visualization_schedule
+ament_target_dependencies(rmf_visualization_schedule
   PUBLIC
-    rmf_traffic_ros2::rmf_traffic_ros2
-    rmf_traffic::rmf_traffic
-    ${rclcpp_LIBRARIES}
-    ${websocketpp_LIBRARIES}
-    OpenSSL::SSL
-    OpenSSL::Crypto
-    Threads::Threads
-    ${rmf_traffic_msgs_LIBRARIES}
+    rmf_traffic
+    rmf_traffic_ros2
+    rclcpp
+    websocketpp
+    OpenSSL
+    Threads
+    rmf_traffic_msgs
 )
 
 target_include_directories(rmf_visualization_schedule
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    ${rclcpp_INCLUDE_DIRS}
-    ${WEBSOCKETPP_INCLUDE_DIR}
-    ${OpenSSL_INCLUDE_DIR}
 )
 
 ament_export_dependencies(
@@ -81,23 +76,17 @@ ament_export_targets(rmf_visualization_schedule HAS_LIBRARY_TARGET)
 
 #===============================================================================
 add_library(schedule_visualizer SHARED src/ScheduleVisualizer.cpp)
+ament_target_dependencies(schedule_visualizer
+  PUBLIC
+    rclcpp_components
+    visualization_msgs
+    geometry_msgs
+    rmf_visualization_msgs
+)
 
 target_link_libraries(schedule_visualizer
   PRIVATE
     rmf_visualization_schedule
-    ${rclcpp_components_LIBRARIES}
-    ${visualization_msgs_LIBRARIES}
-    ${geometry_msgs_LIBRARIES}
-    ${rmf_visualization_msgs_LIBRARIES}
-)
-
-target_include_directories(schedule_visualizer
-  PRIVATE
-    ${rclcpp_INCLUDE_DIRS}
-    ${rclcpp_components_INCLUDE_DIRS}
-    ${visualization_msgs_INCLUDE_DIRS}
-    ${geometry_msgs_INCLUDE_DIRS}
-    ${rmf_visualization_msgs_INCLUDE_DIRS}
 )
 
 target_compile_features(schedule_visualizer INTERFACE cxx_std_17)


### PR DESCRIPTION
The build timeout issue has reached Iron on the buildfarm https://build.ros2.org/view/Ibin_uJ64/job/Ibin_uJ64__rmf_visualization_schedule__ubuntu_jammy_amd64__binary/26/.

Backporting #61 to fix the issue. Will bloom a new release after this is merged.