### PR TITLE
Remove humble from ci matrix for main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,5 +20,5 @@ jobs:
         rmf_visualization_obstacles
         rmf_visualization_rviz2_plugins
         rmf_visualization_schedule
-      dist-matrix: '[{"ros_distribution": "humble", "ubuntu_distribution": "jammy"}, {"ros_distribution": "rolling", "ubuntu_distribution": "jammy"}]'
+      dist-matrix: '[{"ros_distribution": "rolling", "ubuntu_distribution": "jammy"}]'
 

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker_image: ['ros:humble-ros-base']
+        docker_image: ['ros:rolling-ros-base']
     container:
       image: ${{ matrix.docker_image }}
     steps:


### PR DESCRIPTION
The codebase in `main` requires `main` branches for some dep packages like `rmf_traffic_ros2` and hence running CI jobs for a `humble` variant will not succeed. 