### PR TITLE
Fix adapter lift request publisher QoS to transient local

### DIFF
--- a/rmf_visualization_rviz2_plugins/src/LiftPanel.cpp
+++ b/rmf_visualization_rviz2_plugins/src/LiftPanel.cpp
@@ -36,10 +36,10 @@ LiftPanel::LiftPanel(QWidget* parent)
     {
       lift_state_callback(std::move(msg));
     });
-  _lift_request_pub = _node->create_publisher<LiftRequest>(
-    LiftRequestTopicName, rclcpp::QoS(10));
   const auto transient_qos = rclcpp::SystemDefaultsQoS()
     .reliable().keep_last(100).transient_local();
+  _lift_request_pub = _node->create_publisher<LiftRequest>(
+    LiftRequestTopicName, transient_qos);
   _adapter_lift_request_pub = _node->create_publisher<LiftRequest>(
     AdapterLiftRequestTopicName, transient_qos);
 

--- a/rmf_visualization_rviz2_plugins/src/LiftPanel.cpp
+++ b/rmf_visualization_rviz2_plugins/src/LiftPanel.cpp
@@ -38,8 +38,10 @@ LiftPanel::LiftPanel(QWidget* parent)
     });
   _lift_request_pub = _node->create_publisher<LiftRequest>(
     LiftRequestTopicName, rclcpp::QoS(10));
+  const auto transient_qos = rclcpp::SystemDefaultsQoS()
+    .reliable().keep_last(100).transient_local();
   _adapter_lift_request_pub = _node->create_publisher<LiftRequest>(
-    AdapterLiftRequestTopicName, rclcpp::QoS(10));
+    AdapterLiftRequestTopicName, transient_qos);
 
   create_layout();
   create_connections();
@@ -373,7 +375,7 @@ void LiftPanel::lift_state_callback(LiftState::UniquePtr msg)
 void LiftPanel::display_state(const LiftState& msg)
 {
   std::string floors_str = "";
-  for (const auto f : msg.available_floors)
+  for (const auto& f : msg.available_floors)
     floors_str += f + ", ";
 
   std::string available_modes_str = "";


### PR DESCRIPTION
## Bug fix

### Fixed bug

Since https://github.com/open-rmf/rmf_ros2/pull/310, the qos for `adapter_lift_requests` and `lift_requests` was [changed](https://github.com/open-rmf/rmf_ros2/blame/efccf11088055e283a3a29071ee7a0364f405af6/rmf_fleet_adapter/src/lift_supervisor/Node.cpp#L31-L32) to transient local, rather than volatile.
According to the ROS 2 documentation, Volatile publisher and Transient Local subscriber just doesn't work, and indeed it didn't.

### Fix applied

This PR changes the publisher to use the same QoS as the subscriber (and make the build warning free)