### PR TITLE
Fix warnings issued when running on humble

### DIFF
--- a/rmf_visualization_building_systems/rmf_visualization_building_systems/rmf_visualization_building_systems.py
+++ b/rmf_visualization_building_systems/rmf_visualization_building_systems/rmf_visualization_building_systems.py
@@ -35,10 +35,10 @@ class BuildingSystemsVisualizer(Node):
         self.get_logger().info('Building systems visualizer started...')
 
         qos = QoSProfile(
-            history=History.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+            history=History.KEEP_LAST,
             depth=1,
-            reliability=Reliability.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-            durability=Durability.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
+            reliability=Reliability.RELIABLE,
+            durability=Durability.TRANSIENT_LOCAL)
 
         self.marker_pub = self.create_publisher(
             MarkerArray,


### PR DESCRIPTION
Currently the building visualization system issues the following warnings on humble.
```
[rmf_visualization_building_systems-6] [INFO] [1706257149.805404052] [building_systems_visualizer]: Building systems visualizer started...
[rmf_visualization_building_systems-6] /opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/qos.py:307: UserWarning: HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST is deprecated. Use HistoryPolicy.KEEP_LAST instead.
[rmf_visualization_building_systems-6]   warnings.warn(
[rmf_visualization_building_systems-6] /opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/qos.py:307: UserWarning: ReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE is deprecated. Use ReliabilityPolicy.RELIABLE instead.
[rmf_visualization_building_systems-6]   warnings.warn(
[rmf_visualization_building_systems-6] /opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/qos.py:307: UserWarning: DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL is deprecated. Use DurabilityPolicy.TRANSIENT_LOCAL instead.
[rmf_visualization_building_systems-6]   warnings.warn(

```
This PR migrates away towards the newer API.
