### PR TITLE
Use left-handed rotation for floorplan image

### DIFF
--- a/rmf_visualization_floorplans/src/FloorplanVisualizer.cpp
+++ b/rmf_visualization_floorplans/src/FloorplanVisualizer.cpp
@@ -100,7 +100,7 @@ FloorplanVisualizer::FloorplanVisualizer(const rclcpp::NodeOptions& options)
         Eigen::Quaternionf q = Eigen::AngleAxisf(
           M_PI,
           Eigen::Vector3f::UnitX()) * Eigen::AngleAxisf(
-          image.yaw, Eigen::Vector3f::UnitZ());
+          image.yaw, -Eigen::Vector3f::UnitZ());
         grid.info.origin.orientation.x = q.x();
         grid.info.origin.orientation.y = q.y();
         grid.info.origin.orientation.z = q.z();


### PR DESCRIPTION
While reviewing https://github.com/open-rmf/rmf_traffic_editor/pull/513 I found that the yaw parameter is being misused in the rviz visualization. The rviz canvas seems to use left-handed rotation, which is fairly common in 2D rendering.

This very simple PR fixes our marker publication to match that convention. The [`skewed_hotel` branch](https://github.com/open-rmf/rmf_demos/tree/skewed_hotel) of `rmf_demos` can be used to test this PR.