### PR TITLE
fix auth bypass

### DIFF
--- a/rmf_visualization_schedule/src/rmf_visualization_schedule/TrajectoryServer.cpp
+++ b/rmf_visualization_schedule/src/rmf_visualization_schedule/TrajectoryServer.cpp
@@ -138,6 +138,8 @@ auto TrajectoryServer::Implementation::on_message(
       std::string err_excp = e.what();
       send_error_message(hdl, msg, err_response, server, err_excp);
       std::cerr << "Error: " << e.what() << std::endl;
+      server->close(hdl, websocketpp::close::status::normal,
+        "invalid auth token");
       return;
     }
   }

--- a/rmf_visualization_schedule/src/rmf_visualization_schedule/TrajectoryServer.cpp
+++ b/rmf_visualization_schedule/src/rmf_visualization_schedule/TrajectoryServer.cpp
@@ -118,8 +118,6 @@ auto TrajectoryServer::Implementation::on_message(
     return;
   }
 
-  bool ok = parse_request(hdl, msg, response);
-
   // validate jwt only if public key is given (when running with dashboard)
   std::string public_key;
   std::string token;
@@ -137,14 +135,16 @@ auto TrajectoryServer::Implementation::on_message(
     }
     catch (std::exception& e)
     {
-      is_verified = false;
       std::string err_excp = e.what();
       send_error_message(hdl, msg, err_response, server, err_excp);
       std::cerr << "Error: " << e.what() << std::endl;
+      return;
     }
   }
 
-  if (ok && is_verified)
+  bool ok = parse_request(hdl, msg, response);
+
+  if (ok)
   {
     RCLCPP_DEBUG(schedule_data_node->get_logger(),
       "Response: %s", response.c_str());


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

Something I discovered while reviewing https://github.com/open-rmf/rmf_deployment_template/pull/49. I'm 100% certain if this is an actual bypass in practice as I haven't done a POC, but in theory from what I understand from the code, certain requests can bypass authentication.

https://github.com/open-rmf/rmf_visualization/blob/ef42bb42d5749076c0d321864e1b06eea1378e9a/rmf_visualization_schedule/src/rmf_visualization_schedule/TrajectoryServer.cpp#L121-L145

Here the request is parsed first *before* auth is checked, in this case "parsing" the request includes processing it. For most requests this can leak information with a timing attack, but there is one operation in particular which is very problematic.

https://github.com/open-rmf/rmf_visualization/blob/ef42bb42d5749076c0d321864e1b06eea1378e9a/rmf_visualization_schedule/src/rmf_visualization_schedule/TrajectoryServer.cpp#L233-L241

The `negotiation_update_subscribe` request subscribes to negotiation updates and the server will push any new negotiations.

https://github.com/open-rmf/rmf_visualization/blob/ef42bb42d5749076c0d321864e1b06eea1378e9a/rmf_visualization_schedule/src/rmf_visualization_schedule/TrajectoryServer.cpp#L445-L473

Because the request is processed *before* auth, the subscription should *still* go through even with bad credentials and the server will start pushing updates.

### Fix applied

Perform auth before processing any request, also close the connection if auth fails.
