### PR TITLE
Replace ament_target_dependencies with target_link_libraries

### DIFF
--- a/rmf_visualization_fleet_states/CMakeLists.txt
+++ b/rmf_visualization_fleet_states/CMakeLists.txt
@@ -22,14 +22,14 @@ endforeach()
 #===============================================================================
 add_library(fleetstates_visualizer SHARED src/FleetStatesVisualizer.cpp)
 
-ament_target_dependencies(fleetstates_visualizer
+target_link_libraries(fleetstates_visualizer
   PUBLIC
-    rclcpp
-    rclcpp_components
-    rmf_fleet_msgs
-    rmf_visualization_msgs
-    visualization_msgs
-    geometry_msgs
+    rclcpp::rclcpp
+    rclcpp_components::component
+    ${rmf_fleet_msgs_TARGETS}
+    ${rmf_visualization_msgs_TARGETS}
+    ${visualization_msgs_TARGETS}
+    ${geometry_msgs_TARGETS}
 )
 
 target_include_directories(fleetstates_visualizer

--- a/rmf_visualization_floorplans/CMakeLists.txt
+++ b/rmf_visualization_floorplans/CMakeLists.txt
@@ -25,18 +25,17 @@ endforeach()
 #===============================================================================
 add_library(floorplan_visualizer SHARED src/FloorplanVisualizer.cpp)
 
-ament_target_dependencies(floorplan_visualizer
+target_link_libraries(floorplan_visualizer
   PUBLIC
-    rclcpp
-    Eigen3
-    rclcpp_components
-    OpenCV
-    rmf_building_map_msgs
-    rmf_visualization_msgs
-    nav_msgs
-    geometry_msgs
+    rclcpp::rclcpp
+    Eigen3::Eigen
+    rclcpp_components::component
+    opencv_core
+    ${rmf_building_map_msgs_TARGETS}
+    ${rmf_visualization_msgs_TARGETS}
+    ${nav_msgs_TARGETS}
+    ${geometry_msgs_TARGETS}
 )
-
 
 target_include_directories(floorplan_visualizer
   PRIVATE

--- a/rmf_visualization_navgraphs/CMakeLists.txt
+++ b/rmf_visualization_navgraphs/CMakeLists.txt
@@ -26,16 +26,16 @@ endforeach()
 #===============================================================================
 add_library(navgraph_visualizer SHARED src/NavGraphVisualizer.cpp)
 
-ament_target_dependencies(navgraph_visualizer
+target_link_libraries(navgraph_visualizer
   PUBLIC
-    rclcpp
-    rclcpp_components
-    rmf_fleet_msgs
-    rmf_building_map_msgs
-    rmf_visualization_msgs
-    visualization_msgs
-    geometry_msgs
-    rmf_traffic_ros2
+    rclcpp::rclcpp
+    rclcpp_components::component
+    ${rmf_fleet_msgs_TARGETS}
+    ${rmf_building_map_msgs_TARGETS}
+    ${rmf_visualization_msgs_TARGETS}
+    ${visualization_msgs_TARGETS}
+    ${geometry_msgs_TARGETS}
+    ${rmf_traffic_ros2_TARGETS}
 )
 
 target_include_directories(navgraph_visualizer

--- a/rmf_visualization_obstacles/CMakeLists.txt
+++ b/rmf_visualization_obstacles/CMakeLists.txt
@@ -18,15 +18,15 @@ find_package(rmf_visualization_msgs REQUIRED)
 #===============================================================================
 add_library(obstacle_visualizer SHARED src/ObstacleVisualizer.cpp)
 
-ament_target_dependencies(obstacle_visualizer
+target_link_libraries(obstacle_visualizer
   PUBLIC
-    rclcpp
-    rclcpp_components
-    visualization_msgs
-    geometry_msgs
-    vision_msgs
-    rmf_obstacle_msgs
-    rmf_visualization_msgs
+    rclcpp::rclcpp
+    rclcpp_components::component
+    ${visualization_msgs_TARGETS}
+    ${geometry_msgs_TARGETS}
+    ${vision_msgs_TARGETS}
+    ${rmf_obstacle_msgs_TARGETS}
+    ${rmf_visualization_msgs_TARGETS}
 )
 
 target_compile_features(obstacle_visualizer INTERFACE cxx_std_17)

--- a/rmf_visualization_rviz2_plugins/CMakeLists.txt
+++ b/rmf_visualization_rviz2_plugins/CMakeLists.txt
@@ -56,20 +56,16 @@ add_library(${PROJECT_NAME} SHARED
   src/NegotiationModel.cpp
 )
 
-ament_target_dependencies(${PROJECT_NAME}
-  PUBLIC
-    rclcpp
-    rmf_door_msgs
-    rmf_lift_msgs
-    rmf_visualization_msgs
-    rmf_traffic_ros2
-    rviz_common
-    rviz_rendering
-    rviz_default_plugins
-)
-
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
+    rclcpp::rclcpp
+    ${rmf_door_msgs_TARGETS}
+    ${rmf_lift_msgs_TARGETS}
+    ${rmf_visualization_msgs_TARGETS}
+    rmf_traffic_ros2::rmf_traffic_ros2
+    rviz_common::rviz_common
+    rviz_rendering::rviz_rendering
+    rviz_default_plugins::rviz_default_plugins
     ${QT5_LIBRARIES}
     ${Qt5Widgets_LIBRARIES}
 )

--- a/rmf_visualization_schedule/CMakeLists.txt
+++ b/rmf_visualization_schedule/CMakeLists.txt
@@ -86,10 +86,6 @@ target_link_libraries(schedule_visualizer
     rmf_visualization_schedule
 )
 
-target_link_libraries(schedule_visualizer
-
-)
-
 target_compile_features(schedule_visualizer INTERFACE cxx_std_17)
 
 rclcpp_components_register_node(schedule_visualizer

--- a/rmf_visualization_schedule/CMakeLists.txt
+++ b/rmf_visualization_schedule/CMakeLists.txt
@@ -48,15 +48,15 @@ endif()
 file(GLOB_RECURSE core_lib_srcs "src/rmf_visualization_schedule/*.cpp")
 add_library(rmf_visualization_schedule SHARED ${core_lib_srcs})
 
-ament_target_dependencies(rmf_visualization_schedule
+target_link_libraries(rmf_visualization_schedule
   PUBLIC
-    rmf_traffic
-    rmf_traffic_ros2
-    rclcpp
-    websocketpp
-    OpenSSL
-    Threads
-    rmf_traffic_msgs
+    rmf_traffic::rmf_traffic
+    rmf_traffic_ros2::rmf_traffic_ros2
+    rclcpp::rclcpp
+    websocketpp::websocketpp
+    OpenSSL::SSL
+    Threads::Threads
+    ${rmf_traffic_msgs_TARGETS}
 )
 
 target_include_directories(rmf_visualization_schedule
@@ -76,17 +76,18 @@ ament_export_targets(rmf_visualization_schedule HAS_LIBRARY_TARGET)
 
 #===============================================================================
 add_library(schedule_visualizer SHARED src/ScheduleVisualizer.cpp)
-ament_target_dependencies(schedule_visualizer
+target_link_libraries(schedule_visualizer
   PUBLIC
-    rclcpp_components
-    visualization_msgs
-    geometry_msgs
-    rmf_visualization_msgs
+    rclcpp_components::component
+    ${visualization_msgs_TARGETS}
+    ${geometry_msgs_TARGETS}
+    ${rmf_visualization_msgs_TARGETS}
+  PRIVATE
+    rmf_visualization_schedule
 )
 
 target_link_libraries(schedule_visualizer
-  PRIVATE
-    rmf_visualization_schedule
+
 )
 
 target_compile_features(schedule_visualizer INTERFACE cxx_std_17)


### PR DESCRIPTION
`ament_target_dependencies` is deprecated on `kilted` and removed in `rolling`,  It will require a new release on `rolling`.


Debs are broken https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__rmf_visualization_navgraphs__ubuntu_noble_amd64__binary/