### PR TITLE
Link all needed opencv libraries

### DIFF
--- a/rmf_visualization_floorplans/CMakeLists.txt
+++ b/rmf_visualization_floorplans/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(floorplan_visualizer
     Eigen3::Eigen
     rclcpp_components::component
     opencv_core
+    opencv_imgcodecs
     ${rmf_building_map_msgs_TARGETS}
     ${rmf_visualization_msgs_TARGETS}
     ${nav_msgs_TARGETS}


### PR DESCRIPTION
As of #82, the floorplan visualizer is actually broken, trying to run `rmf_demos` returns the following error:

```
[floorplan_visualizer_node-8] /usr/local/google/home/lucadv/noble_ws/install/rmf_visualization_floorplans/lib/rmf_visualization_floorplans/floorplan_visualizer_node: symbol lookup error: /usr/local/google/home/lucadv/noble_ws/install/rmf_visualization_floorplans/lib/libfloorplan_visualizer.so: undefined symbol: _ZN2cv8imdecodeERKNS_11_InputArrayEi
```

The required `imdecode` function is included in the `imgcodecs` [module](https://docs.opencv.org/4.11.0/d4/da8/group__imgcodecs.html) that we need to link against. This PR fixes the issue.