### PR TITLE
Resolve warnings

### DIFF
--- a/rmf_visualization_rviz2_plugins/src/LiftPanel.cpp
+++ b/rmf_visualization_rviz2_plugins/src/LiftPanel.cpp
@@ -377,7 +377,7 @@ void LiftPanel::lift_state_callback(LiftState::UniquePtr msg)
 void LiftPanel::display_state(const LiftState& msg)
 {
   std::string floors_str = "";
-  for (const auto f : msg.available_floors)
+  for (const auto& f : msg.available_floors)
     floors_str += f + ", ";
 
   std::string available_modes_str = "";

--- a/rmf_visualization_rviz2_plugins/src/NegotiationModel.cpp
+++ b/rmf_visualization_rviz2_plugins/src/NegotiationModel.cpp
@@ -63,6 +63,7 @@ uint64_t NegotiationModel::get_negotiation_id(std::size_t n)
     }
     _current_row++;
   }
+  return 0;
 }
 
 QString NegotiationModel::render_participants(uint64_t conflict_version)

--- a/rmf_visualization_schedule/src/rmf_visualization_schedule/ScheduleDataNode.cpp
+++ b/rmf_visualization_schedule/src/rmf_visualization_schedule/ScheduleDataNode.cpp
@@ -74,7 +74,7 @@ std::shared_ptr<ScheduleDataNode> ScheduleDataNode::make(
 {
   const auto start_time = std::chrono::steady_clock::now();
   std::shared_ptr<ScheduleDataNode> schedule_data(
-    new ScheduleDataNode(std::move(node_name), options));
+    new ScheduleDataNode(node_name, options));
 
   // Creating a mirror manager that queries over all
   // Spacetime in the database schedule

--- a/rmf_visualization_schedule/src/rmf_visualization_schedule/TrajectoryServer.cpp
+++ b/rmf_visualization_schedule/src/rmf_visualization_schedule/TrajectoryServer.cpp
@@ -121,7 +121,6 @@ auto TrajectoryServer::Implementation::on_message(
   // validate jwt only if public key is given (when running with dashboard)
   std::string public_key;
   std::string token;
-  bool is_verified = true;
   if (std::getenv("JWT_PUBLIC_KEY"))
   {
     public_key = std::getenv("JWT_PUBLIC_KEY");


### PR DESCRIPTION
## Bug fix

### Fixed bug

Taking inspiration from https://github.com/open-rmf/rmf_traffic/pull/132, I performed source builds of Open-RMF and asked the agent to list out compilation warnings with easy and non-intrusive fixes throughout the code base.

More PRs will be opened in other repositories.

### Fix applied

* missing references
* missing return
* unnecessary `std::move` calls
* unused parameters or variables

I've skipped any of the required changes that were too intrusive to reduce the compiler warnings.

Overall stats regarding compilation warnings that were not related to thirdparty libraries or vendored libraries,
* compilation warnings on main: ~187
* after fixes throughout codebase: ~86
* reduced 101 warnings (-54%)

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [x] I used a GenAI tool in this PR.
- [ ] I did not use GenAI

Generated-by: Claude Sonnet 4.6
